### PR TITLE
Update path to sul-logo-stacked.svg

### DIFF
--- a/libcal/footer.html
+++ b/libcal/footer.html
@@ -6,7 +6,7 @@
 
 
           <div class="content">
-            <div class="sul-footer-img"><a href="https://library.stanford.edu"><img alt="Stanford University Libraries" src="https://library.stanford.edu/sites/all/themes/sulair2016/assets/images/sul-logo-stacked.svg" height="45"></a></div>
+            <div class="sul-footer-img"><a href="https://library.stanford.edu"><img alt="Stanford University Libraries" src="https://searchworks.stanford.edu/assets/sul-logo-stacked-f323e9e37d803f7c6dffee3e7560f4836ec009b77502aac21196bc5545bee7f2.svg" height="45"></a></div>
             <ul class="sul-footer-menu">
               <li><a href="https://library.stanford.edu/hours">Hours</a></li>
               <li><a href="https://library.stanford.edu/myaccount">My Account</a></li>


### PR DESCRIPTION
This logo has been obsoleted and is no longer on the library web site. We can use a copy that is still in searchworks until we upgrade the designs here.