### PR TITLE
Change grays used for background colors to improve contrast

### DIFF
--- a/libguides/head.html
+++ b/libguides/head.html
@@ -199,7 +199,7 @@
   #s-lg-tabs-container>div>.nav-tabs>li.active>button,
   #s-lg-tabs-container>div>.nav-pills>li.active>a,
   #s-lg-tabs-container>div>.nav-pills>li.active>button {
-    background-color: #797268 !important;
+    background-color: #6D6C69 !important;
   }
 
   /* active hover */
@@ -207,7 +207,7 @@
   #s-lg-tabs-container>div>.nav-tabs>li.active>button:hover,
   #s-lg-tabs-container>div>.nav-pills>li.active>a:hover,
   #s-lg-tabs-container>div>.nav-pills>li.active>button:hover {
-    background-color: #60594F !important;
+    background-color: #43423E !important;
   }
 
   .nav>li>a:hover {
@@ -245,7 +245,7 @@
   }
 
   .label-info:hover {
-    background-color: #797268 !important;
+    background-color: #6D6C69 !important;
   }
 
   .label {
@@ -849,7 +849,7 @@
   }
 
   .s-lg-subtab-ul>li.active {
-    background-color: #60594F !important;
+    background-color: #43423E !important;
   }
 
   .s-lg-subtab-ul {


### PR DESCRIPTION
Fixes #11 

Change is already made in production. This just keeps our files in sync with what's saved to libapps.

Before:
<img width="219" alt="image" src="https://github.com/user-attachments/assets/dce84aa7-35b3-48f3-bc85-4ec3fb814178">

After:
<img width="296" alt="Screenshot 2024-10-28 at 2 28 01 PM" src="https://github.com/user-attachments/assets/730c3aa0-bc1d-4575-a380-7441307f1480">
