### PR TITLE
Change profiles text color to black to fix contrast

### DIFF
--- a/libguides/head.html
+++ b/libguides/head.html
@@ -269,6 +269,10 @@
     font-weight: 400 !important;
   }
 
+  #s-lg-profile-count-btn {
+    color: #000;
+  }
+
   .s-lib-box-content {
     padding: 18px 15px 5px 15px !important;
   }


### PR DESCRIPTION
Fixes #12 

Before:
<img width="104" alt="Screenshot 2024-10-28 at 2 38 47 PM" src="https://github.com/user-attachments/assets/25264360-8c1f-4969-9ab8-0c13ee1771ac">

After:
<img width="126" alt="Screenshot 2024-10-28 at 2 36 22 PM" src="https://github.com/user-attachments/assets/07587afc-91e0-46c8-88e7-5d9faf5af9e9">
