### PR TITLE
Set breadcrumb font size to the same as paragraph

### DIFF
--- a/libguides/head.html
+++ b/libguides/head.html
@@ -74,7 +74,7 @@
 
   .breadcrumb {
     font-weight: 400 !important;
-    font-size: 13px !important;
+    font-size: 1rem !important;
     margin-bottom: 12px !important;
     margin-top: 0px !important;
     padding: 12px 0 !important;


### PR DESCRIPTION
Part of #13 

This change is required because the font-size for breadcrumbs is getting set by another [stylesheet](https://static-assets-us.libguides.com/web/css3.12.4/lg-public.min.css) we don't control.

Before:
<img width="682" alt="Screenshot 2024-10-28 at 3 00 04 PM" src="https://github.com/user-attachments/assets/29251084-066d-4bc5-93cd-54d1198ec108">

After:
<img width="825" alt="Screenshot 2024-10-28 at 3 00 20 PM" src="https://github.com/user-attachments/assets/83620574-d8b4-4640-b39a-f9d220abed5a">
