### PR TITLE
Update guides header with markup for new library logo

### DIFF
--- a/libguides/public-header.html
+++ b/libguides/public-header.html
@@ -3,11 +3,7 @@
 <header id="site-header" class="site-header">
 	<div class="site-top-bar">
 		<div class="layout-container">
-
-			<a href="https://library.stanford.edu" class="site-title" id="logo" title="Stanford Libraries" rel="home">
-			<img src="https://mylibrary.stanford.edu/assets/sul-logo-stacked-a844bf7c2eb9f80b28e7f93c8a33dc9e8a1b67ef2d024291d7d891f3004ee7c2.svg" alt="Stanford Libraries" class="logo-small">
-			<img src="https://mylibrary.stanford.edu/assets/sul-logo-3cf10035abd6a94d4daf4fb1e8e27f2d91cafcf9c0e784fad606af2d87d857d8.svg" alt="Stanford Libraries" class="logo-standard">
-			</a>
+			<a href="https://www.stanford.edu" class="su-brand-bar-logo">Stanford University</a>
 			<ul id="secondary-menu-links" class="secondary-menu menu"><li class="menu-968 first"><a href="https://mylibrary.stanford.edu">My Account</a></li>
 			<li class="menu-4838 last"><a id="feedback-link" href="https://library.stanford.edu/ask/email/feedback?source=node/6799" class="enhanced">Feedback</a></li>
 			</ul>
@@ -52,7 +48,9 @@
 			</section></div>
 
 
-
+		<div class="layout-container">
+			<a class="navbar-brand navbar-logo" href="https://library.stanford.edu">Stanford Libraries</a>
+		</div>
 
   	<div class="layout-container">
 		<div class="site-name">


### PR DESCRIPTION
I don't understand why some libapp templates are tracked in this repo and others aren't. In any case, this updates the templates that are tracked to use the new library logo. The rest of the CSS and template changes needed are in files not in this repo.

Updated guides header looks like:
<img width="482" alt="Screenshot 2025-01-15 at 2 13 06 PM" src="https://github.com/user-attachments/assets/debea668-5bad-4038-98dc-79e0965982b5" />
